### PR TITLE
update the package to actually return base64, not dataUri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
 # imageurl-base64 [![npm version](https://badge.fury.io/js/imageurl-base64.png)](https://npmjs.org/package/imageurl-base64)
 
-Node package to convert an image from a url to base64.
+Node package to convert a binary returned from a url to base64/dataUri
 
 ```
 var i2b = require("imageurl-base64");
 
 i2b("http://whateveranyurl.co/anyimage.jpg", callback);
 ```
+
+The callback will return an error object and an object containing the information about the image.
+
+```
+i2b("http://whateveranyurl.co/anyimage.jpg", function(err, data){
+
+});
+```
+
+The data object has the keys `mimeType`, `base64` and `dataUri` - giving you the flexibility to use the dataUri that was returned in previous versions,
+as well being able to get access to the mimeType and the base64 version of the binary returned from the URL.
+
+## Extra notes
+
+This module will give you an object for any URL given to it that returns a binary of any kind, if it's possible. This means that you can also get the data
+for a PDF for example.

--- a/imageurl-base64.js
+++ b/imageurl-base64.js
@@ -9,13 +9,25 @@ var i2b = function (url, callback) {
     };
 
     return request(options, function(e, resp, body) {
-        if (!e && resp.statusCode === 200) {
-            var prefix = "data:" + resp.headers["content-type"] + ";base64,";
-            var img = new Buffer(body.toString(), "binary").toString("base64");
-            return callback(prefix + img);
+        if (e) {
+            return callback(e);
         }
 
-        return callback();
+        if (resp.statusCode !== 200) {
+            var error = new Error('response was non 200');
+            error.response = body;
+            return callback(error);
+        }
+
+        var prefix = "data:" + resp.headers["content-type"] + ";base64,";
+        var img = new Buffer(body.toString(), "binary").toString("base64");
+
+        return callback(null, {
+            mimeType: resp.headers["content-type"],
+            base64: img,
+            dataUri: prefix + img
+        });
+
     });
 };
 


### PR DESCRIPTION
Updated the module to actually give back what it says it does, base64 - base64 !== dataUri :smile: 

I also made it return the error object if there is one, or reply with the error if the response wasn't 200.

This means that if this gets merged and published to npm, it will require a major bump as it changes the returned result from a string to an object, as well as pushing the error object to the first argument in the callback. If the error object had already been there I would have added a flag to return an object, not forcing the major bump but as the error object wasn't there, the major bump is now required.
